### PR TITLE
[FIX] Allow to use dates on introsprection

### DIFF
--- a/odoo_graphql/controllers/graphql.py
+++ b/odoo_graphql/controllers/graphql.py
@@ -17,7 +17,7 @@ class GraphQL(http.Controller):
         # https://spec.graphql.org/June2018/#sec-Response-Format
         query = request.httprequest.data.decode()  # request.graphqlrequest
         response = request.env["graphql.handler"].handle_query(query)
-        payload = json.dumps(response, indent=4)
+        payload = json.dumps(response, indent=4, default=str)
         # print(payload)
         return payload
 


### PR DESCRIPTION
Issue: when using introspection I realised that it is not possible to query dates/datetimes.
Reason: dates/datetimes are not natively JSON serializable.
Solution: use string conversion as default on json.dumps() function.