### PR TITLE
[FIX] Allow querying relational records which are archived

### DIFF
--- a/odoo_graphql/graphql_resolver.py
+++ b/odoo_graphql/graphql_resolver.py
@@ -256,7 +256,7 @@ def relation_subgathers(records, relational_data, variables, field_mapping={}, f
 
             # https://stackoverflow.com/questions/8946868/is-there-a-pythonic-way-to-close-over-a-loop-variable
             def subgather(ids, data=data, limit=limit, offset=offset):
-                if ids is False:
+                if ids is False or not data:
                     return None
                 # We may not receive all ids since records may be archived
                 if isinstance(ids, int):

--- a/odoo_graphql/graphql_resolver.py
+++ b/odoo_graphql/graphql_resolver.py
@@ -256,11 +256,11 @@ def relation_subgathers(records, relational_data, variables, field_mapping={}, f
 
             # https://stackoverflow.com/questions/8946868/is-there-a-pythonic-way-to-close-over-a-loop-variable
             def subgather(ids, data=data, limit=limit, offset=offset):
-                if ids is False or not data:
+                if ids is False:
                     return None
                 # We may not receive all ids since records may be archived
                 if isinstance(ids, int):
-                    return data.get(ids)[1]
+                    return data.get(ids)[1] if data else None
                 # Since the data are gathered in batch, then dispatched,
                 # The order is lost and must be done again.
                 res = slice_result([


### PR DESCRIPTION
When trying to query recordsets with relational fields where the relational record is archived the current implementation runs into a TypeError. For this reason we have to check if the data is actually set before accessing it.