### PR TITLE
Fix invoking toordinal/strftime on bool.

### DIFF
--- a/odoo_graphql/graphql_resolver.py
+++ b/odoo_graphql/graphql_resolver.py
@@ -422,6 +422,8 @@ def _get_type_serializer_date(field, variables=None):
     fmt = data.get("format")
 
     def func(value):
+        if not value:
+            return False
         if fmt:
             return value.strftime(fmt)
         return value.toordinal()


### PR DESCRIPTION
Some date fields (e.g., `date_deadline` in `CrmLead` return false if not specified.  This catches the boolean False and returns it before the `toordinal` or `strftime` methods are called.